### PR TITLE
Add PONG reply to PING messages

### DIFF
--- a/nanoircd.c
+++ b/nanoircd.c
@@ -430,6 +430,10 @@ void ircd_parse(client_t * clients, int k, int num_clients, char *buf)
             char *dest = argv[1];
             reply(cl, dest, ":%s %s %s :%s", mask, cmd, argv[1], argv[2]);
         }
+        else if (!strcmp(cmd, "PING"))
+        {
+            reply(cl, 0, "PONG %s :%s", serv, cl->nickname);
+        }
     }
 }
 


### PR DESCRIPTION
Some clients (e.g. [ii](https://tools.suckless.org/ii/)) will send a PING every n minutes and disconnect
from the server if it doesn't reply with a corresponding PONG message.
(cf [sections 4.6.2 & 4.6.3 of RFC 1459](https://tools.ietf.org/html/rfc1459#section-4.6.2))